### PR TITLE
fix: auth for integration tests, move to io from ioutil, update BuyMCR calls in tests

### DIFF
--- a/config/deafult_logger.go
+++ b/config/deafult_logger.go
@@ -69,7 +69,7 @@ func (d *DefaultLogger) SetLevel(l Level) {
 func (d *DefaultLogger) log(level Level, args ...interface{}) {
 	if level >= d.level {
 		msg := fmt.Sprint(args...)
-		log.Print(fmt.Sprintf("%s: %s", strings.ToUpper(level.String()), msg))
+		log.Printf("%s: %s", strings.ToUpper(level.String()), msg)
 	}
 }
 
@@ -101,7 +101,7 @@ func (d *DefaultLogger) Error(args ...interface{}) {
 func (d *DefaultLogger) logf(level Level, format string, args ...interface{}) {
 	if level >= d.level {
 		msg := fmt.Sprintf(format, args...)
-		log.Print(fmt.Sprintf("%s: %s", strings.ToUpper(level.String()), msg))
+		log.Printf("%s: %s", strings.ToUpper(level.String()), msg)
 	}
 }
 

--- a/service/authentication/authentication.go
+++ b/service/authentication/authentication.go
@@ -42,6 +42,7 @@ type Authentication struct {
 }
 
 func New(cfg *config.Config) *Authentication {
+	cfg.Client = config.NewHttpClient()
 	return &Authentication{
 		Config: cfg,
 	}

--- a/service/authentication/authentication_integ_test.go
+++ b/service/authentication/authentication_integ_test.go
@@ -92,32 +92,3 @@ func TestLoginOauth(t *testing.T) {
 
 	logger.Info(token)
 }
-
-func TestLoginUsername(t *testing.T) {
-
-	if username == "" {
-		logger.Error("MEGAPORT_USERNAME environment variable not set.")
-		os.Exit(1)
-	}
-
-	if password == "" {
-		logger.Error("MEGAPORT_PASSWORD environment variable not set.")
-		os.Exit(1)
-	}
-
-	auth := New(&cfg)
-	token, loginErr := auth.LoginUsername(username, password, otp)
-
-	assert.NoError(t, loginErr)
-
-	if loginErr != nil {
-		logger.Errorf("LoginError: %s", loginErr.Error())
-	}
-
-	// Session Token is not empty
-	assert.NotEmpty(t, token)
-	// SessionToken is a valid guid
-	assert.NotNil(t, shared.IsGuid(token))
-
-	logger.Info(token)
-}

--- a/service/location/location.go
+++ b/service/location/location.go
@@ -23,6 +23,7 @@ package location
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"io/ioutil"
 
 	"github.com/lithammer/fuzzysearch/fuzzy"
@@ -91,7 +92,7 @@ func (l *Location) GetAllLocations() ([]types.Location, error) {
 		return nil, compiledResError
 	}
 
-	body, fileErr := ioutil.ReadAll(response.Body)
+	body, fileErr := io.ReadAll(response.Body)
 
 	if fileErr != nil {
 		return nil, fileErr

--- a/service/location/location_integ_test.go
+++ b/service/location/location_integ_test.go
@@ -62,8 +62,8 @@ func TestMain(m *testing.M) {
 		Endpoint: MEGAPORTURL,
 	}
 
-	auth := authentication.New(&cfg, clientID, clientSecret)
-	token, loginErr := auth.Login()
+	auth := authentication.New(&cfg)
+	token, loginErr := auth.LoginOauth(clientID, clientSecret)
 
 	if loginErr != nil {
 		logger.Errorf("LoginError: %s", loginErr.Error())

--- a/service/mcr/mcr_integ_test.go
+++ b/service/mcr/mcr_integ_test.go
@@ -67,8 +67,8 @@ func TestMain(m *testing.M) {
 		Endpoint: MEGAPORTURL,
 	}
 
-	auth := authentication.New(&cfg, clientID, clientSecret)
-	token, loginErr := auth.Login()
+	auth := authentication.New(&cfg)
+	token, loginErr := auth.LoginOauth(clientID, clientSecret)
 
 	if loginErr != nil {
 		logger.Errorf("LoginError: %s", loginErr.Error())
@@ -87,7 +87,7 @@ func TestMCRLifecycle(t *testing.T) {
 	testLocation := location.GetRandom(TEST_MCR_TEST_LOCATION_MARKET)
 
 	logger.Debugf("Test location determined, Location: %s", testLocation.Name)
-	mcrId, portErr := mcr.BuyMCR(testLocation.ID, "Buy MCR", 1000, 0)
+	mcrId, portErr := mcr.BuyMCR(testLocation.ID, "Buy MCR", 1, 1000, 0)
 
 	if !assert.NoError(portErr) && assert.False(shared.IsGuid(mcrId)) {
 		mcr.Config.PurchaseError(mcrId, portErr)
@@ -150,7 +150,7 @@ func TestMCRConnectionAdd(t *testing.T) {
 	logger.Infof("Test location determined, Location: %s", testLocation.Name)
 	logger.Debug("Buying MCR")
 
-	mcrId, mcrErr := mcr.BuyMCR(testLocation.ID, "MCR and AWS Interconnectivity", 1000, 0)
+	mcrId, mcrErr := mcr.BuyMCR(testLocation.ID, "MCR and AWS Interconnectivity", 1, 1000, 0)
 
 	logger.Infof("MCR Purchased: %s", mcrId)
 
@@ -234,7 +234,7 @@ func TestPortSpeedValidation(t *testing.T) {
 	location := location.New(&cfg)
 
 	testLocation, _ := location.GetLocationByName("Global Switch Sydney")
-	_, buyErr := mcr.BuyMCR(testLocation.ID, "Test MCR", 500, 0)
+	_, buyErr := mcr.BuyMCR(testLocation.ID, "Test MCR", 1, 500, 0)
 	assert.EqualError(buyErr, mega_err.ERR_MCR_INVALID_PORT_SPEED)
 }
 
@@ -247,7 +247,7 @@ func TestCreatePrefixFilterList(t *testing.T) {
 	testLocation := location.GetRandom(TEST_MCR_TEST_LOCATION_MARKET)
 
 	logger.Infof("Test location determined, Location: %s", testLocation.Name)
-	mcrId, portErr := mcr.BuyMCR(testLocation.ID, "Buy MCR", 1000, 0)
+	mcrId, portErr := mcr.BuyMCR(testLocation.ID, "Buy MCR", 1, 1000, 0)
 
 	if !assert.NoError(portErr) && assert.False(shared.IsGuid(mcrId)) {
 		mcr.Config.PurchaseError(mcrId, portErr)

--- a/service/partner/partner.go
+++ b/service/partner/partner.go
@@ -18,7 +18,7 @@ package partner
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 
 	"github.com/lithammer/fuzzysearch/fuzzy"
 	"github.com/megaport/megaportgo/config"
@@ -48,7 +48,7 @@ func (p *Partner) GetAllPartnerMegaports() ([]types.PartnerMegaport, error) {
 	}
 	defer response.Body.Close()
 
-	body, fileErr := ioutil.ReadAll(response.Body)
+	body, fileErr := io.ReadAll(response.Body)
 
 	if fileErr != nil {
 		return []types.PartnerMegaport{}, fileErr

--- a/service/partner/partner_integ_test.go
+++ b/service/partner/partner_integ_test.go
@@ -62,8 +62,8 @@ func TestMain(m *testing.M) {
 		Endpoint: MEGAPORTURL,
 	}
 
-	auth := authentication.New(&cfg, clientID, clientSecret)
-	token, loginErr := auth.Login()
+	auth := authentication.New(&cfg)
+	token, loginErr := auth.LoginOauth(clientID, clientSecret)
 
 	if loginErr != nil {
 		logger.Errorf("LoginError: %s", loginErr.Error())

--- a/service/port/port.go
+++ b/service/port/port.go
@@ -19,7 +19,7 @@ package port
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"slices"
 	"time"
 
@@ -56,7 +56,7 @@ func (p *Port) BuyPort(name string, term int, portSpeed int, locationId int, mar
 
 	if isLAG {
 		buyOrder = []types.PortOrder{
-			types.PortOrder{
+			{
 				Name:                  name,
 				Term:                  term,
 				ProductType:           "MEGAPORT",
@@ -71,7 +71,7 @@ func (p *Port) BuyPort(name string, term int, portSpeed int, locationId int, mar
 		}
 	} else {
 		buyOrder = []types.PortOrder{
-			types.PortOrder{
+			{
 				Name:                  name,
 				Term:                  term,
 				ProductType:           "MEGAPORT",
@@ -123,7 +123,7 @@ func (p *Port) GetPortDetails(id string) (types.Port, error) {
 		return types.Port{}, parsedError
 	}
 
-	body, fileErr := ioutil.ReadAll(response.Body)
+	body, fileErr := io.ReadAll(response.Body)
 
 	if fileErr != nil {
 		return types.Port{}, fileErr
@@ -156,7 +156,7 @@ func (p *Port) GetPorts() ([]types.Port, error) {
 		return []types.Port{}, parsedError
 	}
 
-	body, fileErr := ioutil.ReadAll(response.Body)
+	body, fileErr := io.ReadAll(response.Body)
 
 	if fileErr != nil {
 		return []types.Port{}, fileErr

--- a/service/port/port_integ_test.go
+++ b/service/port/port_integ_test.go
@@ -67,8 +67,8 @@ func TestMain(m *testing.M) {
 		Endpoint: MEGAPORTURL,
 	}
 
-	auth := authentication.New(&cfg, clientID, clientSecret)
-	token, loginErr := auth.Login()
+	auth := authentication.New(&cfg)
+	token, loginErr := auth.LoginOauth(clientID, clientSecret)
 
 	if loginErr != nil {
 		logger.Errorf("LoginError: %s", loginErr.Error())

--- a/service/vxc/partner.go
+++ b/service/vxc/partner.go
@@ -17,7 +17,7 @@ package vxc
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"github.com/megaport/megaportgo/mega_err"
@@ -41,7 +41,7 @@ func (v *VXC) LookupPartnerPorts(key string, portSpeed int, partner string, requ
 		return "", compiledErr
 	}
 
-	body, fileErr := ioutil.ReadAll(response.Body)
+	body, fileErr := io.ReadAll(response.Body)
 
 	if fileErr != nil {
 		return "", fileErr

--- a/service/vxc/vxc_integ_test.go
+++ b/service/vxc/vxc_integ_test.go
@@ -71,8 +71,8 @@ func TestMain(m *testing.M) {
 		Endpoint: MEGAPORTURL,
 	}
 
-	auth := authentication.New(&cfg, clientID, clientSecret)
-	token, loginErr := auth.Login()
+	auth := authentication.New(&cfg)
+	token, loginErr := auth.LoginOauth(clientID, clientSecret)
 
 	if loginErr != nil {
 		logger.Errorf("LoginError: %s", loginErr.Error())
@@ -230,7 +230,7 @@ func TestAWSHostedConnectionBuy(t *testing.T) {
 	testLocation := loc.GetRandom(MCR_LOCATION)
 
 	logger.Info("Buying AWS Hosted Connection MCR (A End).")
-	mcrId, mcrErr := mcr.BuyMCR(testLocation.ID, "AWS Hosted Conection Test MCR", 1000, 0)
+	mcrId, mcrErr := mcr.BuyMCR(testLocation.ID, "AWS Hosted Conection Test MCR", 1, 1000, 0)
 	logger.Infof("MCR Purchased: %s", mcrId)
 
 	if !assert.NoError(t, mcrErr) && !assert.True(t, shared.IsGuid(mcrId)) {
@@ -249,7 +249,7 @@ func TestAWSHostedConnectionBuy(t *testing.T) {
 			VLAN: shared.GenerateRandomVLAN(),
 			PartnerConfig: types.VXCOrderAEndPartnerConfig{
 				Interfaces: []types.PartnerConfigInterface{
-					types.PartnerConfigInterface{
+					{
 						IpAddresses: []string{"10.0.0.1/30"},
 						IpRoutes: []types.IpRoute{
 							{
@@ -282,7 +282,7 @@ func TestAWSHostedConnectionBuy(t *testing.T) {
 			},
 		},
 		types.AWSVXCOrderBEndConfiguration{
-			ProductUID: "b2e0b6b8-2943-4c44-8a07-9ec13060afb2",
+			ProductUID: "b047870a-adcf-441f-ae34-27a796cdafeb",
 			PartnerConfig: types.AWSVXCOrderBEndPartnerConfig{
 				ConnectType:  "AWSHC",
 				Type:         "private",

--- a/test/create-user.go
+++ b/test/create-user.go
@@ -40,15 +40,18 @@ func main() {
 	logger := config.NewDefaultLogger()
 	logger.SetLevel(config.Off)
 
+	client := config.NewHttpClient()
+
 	cfg := config.Config{
 		Log:      logger,
 		Endpoint: ENDPOINTURL,
+		Client:   client,
 	}
 
-	auth := authentication.New(&cfg, username, password, "")
+	auth := authentication.New(&cfg)
 
 	fmt.Println("Establishing Session for user")
-	session, err := auth.Login()
+	session, err := auth.LoginOauth(username, password)
 	if err != nil {
 		fmt.Println("Unable to establish session for user: ", err)
 		os.Exit(1)


### PR DESCRIPTION
- Update auth in various integration tests
- Use valid UID in `TestAWSHostedConnectionBuy` call to fix failing API request
- Use `io` instead of deprecated `ioutil`
- Update logs with string interpolation to use `log.Printf`
- Cleanup of redundant types in `types.PortOrder` slices
- Initialize http client to prevent nil pointer panics in auth tests